### PR TITLE
Add toml to dependency list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ setup_requires =
 python_requires = >=3.6
 install_requires =
     volatile>=1.0
+    toml>=0.10.2
     pep517>=0.6.0
     honesty==0.3.0a1
     highlighter>=0.1.1


### PR DESCRIPTION
It's used in `pessimist.util`, and no longer in transitive deps.